### PR TITLE
Destroy underlying socket when connect fails

### DIFF
--- a/src/connection/ElkSocketConnection.test.ts
+++ b/src/connection/ElkSocketConnection.test.ts
@@ -310,13 +310,7 @@ describe('ElkSocketConnection', () => {
 
     describe('times out', () => {
       beforeEach(() => {
-        mockCreateSocketConnectsSuccessfully();
-        mocked(createSocket).mockImplementation(() => {
-          const mock = new SocketMock();
-          mock.setConnecting();
-          setTimeout(() => mock.setConnected(), 10);
-          return mock;
-        });
+        mockCreateSocketConnectsSuccessfully(10);
         connection = new ElkSocketConnection();
       });
 
@@ -491,7 +485,7 @@ describe('ElkSocketConnection', () => {
       });
 
       afterEach(async () => {
-        connectPromise.catch(() => undefined);
+        return connectPromise.catch(() => undefined);
       });
 
       it('cancels the connect and resolves', async () => {

--- a/src/connection/ElkSocketConnection.ts
+++ b/src/connection/ElkSocketConnection.ts
@@ -216,6 +216,7 @@ class ElkSocketConnection extends EventEmitter implements ElkConnection {
       })
     )
       .catch(error => {
+        socket.destroy();
         socket.removeListener('connect', connectListener);
         this.removeListener('error', errorListener);
         this.removeListener('disconnecting', disconnectingListener);
@@ -240,11 +241,12 @@ class ElkSocketConnection extends EventEmitter implements ElkConnection {
 
     return withTimeout<ElkSocketConnection>(
       timeout,
-      new Promise((resolve, reject) => {
+      new Promise(resolve => {
         if (!this._socket) {
           // Already disconnected, just resolve.
           return resolve(this);
         }
+
         socket = this._socket;
 
         if (this.state === ElkConnectionState.Connecting) {


### PR DESCRIPTION
If an `ElkSocketConnection.connect()` call fails, the socket needs to be destroyed explicitly because the failure may have been called by our own timeout -- in which case it could still eventually end up connecting at some point and the connection would be left open with no one knowing about it.