### PR TITLE
fix: rejections potentially unhandled

### DIFF
--- a/src/ElkClientEvents.ts
+++ b/src/ElkClientEvents.ts
@@ -66,7 +66,7 @@ declare function error(error: Error): void;
  * @asMemberOf ElkClientEvents
  * @event
  */
-declare function disconnected(error?: Error): void;
+declare function disconnected(error?: Error): void; // tslint:disable-line:handle-callback-err
 
 export default interface ElkClientEvents {
   addListener(event: 'connected', listener: typeof connected): this;


### PR DESCRIPTION
If these aren't handled/ignored they will cause an unhandledRejection error. They will ultimately get dealt with by the `error` callback handlers, so they are safe to ignore.